### PR TITLE
feat: add Artist section with SoundCloud and Flow Music player

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,11 @@ RUN pnpm run build
 
 EXPOSE 3000
 
-# Drop privileges
+# Drop privileges. Chown .next so the unprivileged user can write
+# the image-optimization cache (.next/cache/images) at runtime.
 RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nextjs -u 1001
+    adduser -S nextjs -u 1001 && \
+    chown -R nextjs:nodejs /app/.next
 USER nextjs
 
 # Server-only secrets (e.g., YOUTUBE_API_KEY) come in at runtime via:

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,14 @@
 // @ts-check
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  /* config options here */
+  turbopack: {
+    root: __dirname,
+  },
   async redirects() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.18",
+    "@types/three": "^0.184.0",
     "autoprefixer": "10.4.15",
     "eslint": "8.47.0",
     "eslint-config-next": "13.4.15",
@@ -25,7 +26,8 @@
     "react-type-animation": "^3.1.0",
     "resend": "^1.0.0",
     "sharp": "^0.34.4",
-    "tailwindcss": "^3.4.1"
+    "tailwindcss": "^3.4.1",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@types/node": "20.10.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@heroicons/react':
     specifier: ^2.0.18
     version: 2.2.0(react@18.3.1)
+  '@types/three':
+    specifier: ^0.184.0
+    version: 0.184.0
   autoprefixer:
     specifier: 10.4.15
     version: 10.4.15(postcss@8.5.12)
@@ -44,6 +47,9 @@ dependencies:
   tailwindcss:
     specifier: ^3.4.1
     version: 3.4.19
+  three:
+    specifier: ^0.184.0
+    version: 0.184.0
 
 devDependencies:
   '@types/node':
@@ -70,6 +76,10 @@ packages:
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+    dev: false
+
+  /@dimforge/rapier3d-compat@0.12.0:
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
     dev: false
 
   /@emnapi/core@1.10.0:
@@ -1023,6 +1033,10 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@tweenjs/tween.js@23.1.3:
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+    dev: false
+
   /@tybys/wasm-util@0.10.1:
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
     requiresBuild: true
@@ -1060,6 +1074,25 @@ packages:
   /@types/scheduler@0.26.0:
     resolution: {integrity: sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==}
     dev: true
+
+  /@types/stats.js@0.17.4:
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+    dev: false
+
+  /@types/three@0.184.0:
+    resolution: {integrity: sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==}
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.2
+      meshoptimizer: 1.1.1
+    dev: false
+
+  /@types/webxr@0.5.24:
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
+    dev: false
 
   /@typescript-eslint/parser@6.21.0(eslint@8.47.0)(typescript@5.9.3):
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
@@ -2477,7 +2510,6 @@ packages:
 
   /fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
-    dev: true
 
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -3243,6 +3275,10 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  /meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
+    dev: false
 
   /micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -4375,6 +4411,10 @@ packages:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
     dependencies:
       any-promise: 1.3.0
+    dev: false
+
+  /three@0.184.0:
+    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
     dev: false
 
   /tinybench@2.9.0:

--- a/scripts/docker-local.sh
+++ b/scripts/docker-local.sh
@@ -33,8 +33,15 @@ if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER}$"; then
   docker rm -f "${CONTAINER}" >/dev/null
 fi
 
+CACHE_FLAG=""
+if [ "${NO_CACHE:-}" = "1" ]; then
+  echo "▶ NO_CACHE=1 — building without layer cache"
+  CACHE_FLAG="--no-cache"
+fi
+
 echo "▶ Building ${IMAGE}..."
 docker build \
+  ${CACHE_FLAG} \
   --build-arg "NEXT_PUBLIC_YOUTUBE_CHANNEL_ID=${NEXT_PUBLIC_YOUTUBE_CHANNEL_ID}" \
   -t "${IMAGE}" \
   .

--- a/src/app/components/AboutMe/HeroSection.tsx
+++ b/src/app/components/AboutMe/HeroSection.tsx
@@ -96,6 +96,7 @@ const HeroSection = () => {
 							className="rounded-full absolute transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2"
 							width={300}
 							height={300}
+							priority
 						/>
 					</div>
 				</motion.div>

--- a/src/app/components/Artist/ArtistSection.tsx
+++ b/src/app/components/Artist/ArtistSection.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import SoundCloudEmbed from "./SoundCloudEmbed";
+import FlowMusicPlayer from "./FlowMusicPlayer";
+
+const SOUNDCLOUD_PROFILE = "https://soundcloud.com/user-878079272";
+
+const ArtistSection = () => {
+  return (
+    <section id="artist" className="my-12 py-8">
+      <h2 className="text-center text-4xl font-bold text-white mt-4 mb-4">
+        Artist
+      </h2>
+      <p className="text-center text-[#ADB7BE] max-w-2xl mx-auto mb-12">
+        A small corner of the portfolio for the music side of things — original
+        tracks on SoundCloud, plus an experimental player built around clips
+        produced with Google&apos;s Flow Music.
+      </p>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-start">
+        <div>
+          <h3 className="text-xl font-semibold text-white mb-4">SoundCloud</h3>
+          <SoundCloudEmbed
+            profileUrl={SOUNDCLOUD_PROFILE}
+            title="Corey Hurst on SoundCloud"
+            height={720}
+            visual={true}
+            color="14b8a6"
+          />
+        </div>
+        <div>
+          <h3 className="text-xl font-semibold text-white mb-4">
+            Neural Link — Flow Music
+          </h3>
+          <FlowMusicPlayer />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ArtistSection;

--- a/src/app/components/Artist/FlowMusicPlayer.tsx
+++ b/src/app/components/Artist/FlowMusicPlayer.tsx
@@ -1,0 +1,193 @@
+"use client";
+import React, { useState } from "react";
+import Visualizer from "./Visualizer";
+
+const SONGS = [
+  { id: "cf8232d4-266a-4511-bfe2-fd6459bdb1ec", title: "Hold The Space (Focus Mix)" },
+  { id: "476f9218-03a7-41c2-980b-8d7fd6c1d9d7", title: "FastLofi" },
+  { id: "40548315-18f9-4c83-ba1a-c56169b25ccd", title: "Leave The Heavy Behind (Pop-Remix)" },
+];
+
+export default function FlowMusicPlayer() {
+  const [selectedId, setSelectedId] = useState(SONGS[0].id);
+  const [isScanning, setIsScanning] = useState(false);
+  const [viewMode, setViewMode] = useState<"player" | "visualizer">("player");
+  const audioUrl = `https://storage.googleapis.com/producer-app-public/clips/${selectedId}.m4a`;
+
+  const handleSync = () => {
+    setIsScanning(true);
+    setTimeout(() => setIsScanning(false), 2000);
+  };
+
+  return (
+    <div className="relative w-full flex items-center justify-center bg-black p-4 font-mono text-cyan-400 overflow-hidden rounded-2xl border border-cyan-500/20">
+      <style>{`
+        @keyframes glitch {
+          0% { transform: translate(0) }
+          20% { transform: translate(-2px, 2px) }
+          40% { transform: translate(-2px, -2px) }
+          60% { transform: translate(2px, 2px) }
+          80% { transform: translate(2px, -2px) }
+          100% { transform: translate(0) }
+        }
+        @keyframes glitch-skew {
+          0% { transform: skew(0deg) }
+          10% { transform: skew(3deg); opacity: 0.8; }
+          20% { transform: skew(-3deg); opacity: 1; }
+          30% { transform: skew(1deg) }
+          100% { transform: skew(0deg) }
+        }
+        @keyframes view-fade-in {
+          from { opacity: 0; transform: translateY(4px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes view-zoom-in {
+          from { opacity: 0; transform: scale(0.95); }
+          to { opacity: 1; transform: scale(1); }
+        }
+        .animate-glitch {
+          animation: glitch 0.3s cubic-bezier(.25,.46,.45,.94) both infinite;
+        }
+        .view-player-enter {
+          animation: view-fade-in 500ms ease-out both;
+        }
+        .view-visualizer-enter {
+          animation: view-zoom-in 500ms ease-out both;
+        }
+        .glitch-text::before,
+        .glitch-text::after {
+          content: attr(data-text);
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+        }
+        .glitch-text::before {
+          left: 2px;
+          text-shadow: -2px 0 #ff00c1;
+          clip: rect(44px, 450px, 56px, 0);
+          animation: glitch-skew 2s infinite linear alternate-reverse;
+        }
+        .glitch-text::after {
+          left: -2px;
+          text-shadow: -2px 0 #00fff9, 2px 2px #ff00c1;
+          animation: glitch-skew 3s infinite linear alternate-reverse;
+          clip: rect(10px, 450px, 30px, 0);
+        }
+      `}</style>
+
+      {/* Background Grid Effect */}
+      <div className="absolute inset-0 bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:40px_40px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)]" />
+
+      <div className="relative w-full max-w-lg group">
+        <div className="absolute -inset-1 bg-gradient-to-r from-cyan-500 via-fuchsia-500 to-cyan-500 rounded-2xl blur opacity-20" />
+
+        <div className="relative flex flex-col items-center bg-zinc-950 border border-cyan-500/30 rounded-2xl p-8 shadow-[0_0_50px_-12px_rgba(6,182,212,0.4)] backdrop-blur-xl overflow-hidden">
+
+          <div className="absolute inset-0 pointer-events-none bg-[linear-gradient(rgba(18,16,16,0)_50%,rgba(0,0,0,0.25)_50%),linear-gradient(90deg,rgba(255,0,0,0.06),rgba(0,255,0,0.02),rgba(0,0,255,0.06))] bg-[length:100%_2px,3px_100%]" />
+
+          <div className="w-full mb-8 relative flex justify-between items-end">
+            <h1
+              className="glitch-text text-3xl font-black italic tracking-tighter uppercase text-white"
+              data-text="NEURAL LINK"
+            >
+              Neural Link
+            </h1>
+            <span className="text-[10px] bg-cyan-500/10 border border-cyan-500/50 px-2 py-0.5 rounded animate-pulse text-cyan-300">
+              LOCKED // 0xFA42
+            </span>
+          </div>
+
+          <div className="w-full space-y-6 relative z-10">
+            {/* Unified Audio Controller — always mounted so playback survives view toggles */}
+            <div className="w-full p-4 bg-black/60 border border-white/10 rounded-xl space-y-3 relative overflow-hidden">
+              <div className="flex justify-between items-center px-1">
+                <div className="text-[10px] uppercase tracking-widest opacity-80 text-cyan-200">
+                  System Audio Feed
+                </div>
+                <div className="text-[10px] tabular-nums text-fuchsia-300 italic">
+                  ID_{selectedId.slice(0, 8)}
+                </div>
+              </div>
+              <audio
+                key={selectedId}
+                controls
+                className="w-full h-10 [filter:invert(1)_hue-rotate(180deg)_brightness(1.5)_contrast(1.2)]"
+                crossOrigin="anonymous"
+              >
+                <source src={audioUrl} type="audio/mpeg" />
+              </audio>
+            </div>
+
+            {/* Viewport Area */}
+            <div className="min-h-[300px]">
+              {viewMode === "player" ? (
+                <div key="player" className="space-y-6 view-player-enter">
+                  <div className="flex flex-col space-y-3">
+                    <label className="text-[10px] uppercase tracking-[0.2em] font-bold text-cyan-300 flex items-center">
+                      <span className="w-1 h-1 bg-cyan-400 mr-2 animate-ping" />
+                      Select Data Stream
+                    </label>
+                    <select
+                      value={selectedId}
+                      onChange={(e) => setSelectedId(e.target.value)}
+                      aria-label="Select track"
+                      className="w-full bg-black border border-cyan-500/30 rounded px-4 py-4 text-sm focus:outline-none focus:border-cyan-400 appearance-none cursor-pointer hover:bg-zinc-900 transition-all"
+                    >
+                      {SONGS.map((song) => (
+                        <option key={song.id} value={song.id} className="bg-zinc-900">
+                          {song.title.toUpperCase()}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="text-center py-12 border border-dashed border-white/10 rounded-lg">
+                    <div className="text-xs text-white/40 uppercase tracking-[0.5em]">
+                      Standard Interface Active
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div key="visualizer" className="view-visualizer-enter">
+                  <Visualizer />
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-8 flex flex-wrap justify-center gap-4">
+            <button
+              onClick={() => setViewMode(viewMode === "player" ? "visualizer" : "player")}
+              className="group/btn relative px-6 py-2 border border-fuchsia-500/50 rounded-sm overflow-hidden transition-all hover:bg-fuchsia-500/10 shadow-[0_0_15px_rgba(236,72,153,0.2)]"
+            >
+              <span className="relative z-10 text-[10px] font-black tracking-[0.3em] uppercase text-fuchsia-400">
+                {viewMode === "player" ? "OPEN_3D_SCAPE" : "CLOSE_3D_SCAPE"}
+              </span>
+            </button>
+
+            <button
+              onClick={handleSync}
+              className={`group/btn relative px-6 py-2 border border-fuchsia-500/50 rounded-sm overflow-hidden transition-all hover:bg-fuchsia-500/10 shadow-[0_0_15px_rgba(236,72,153,0.2)] ${
+                isScanning ? "animate-glitch" : ""
+              }`}
+            >
+              <span
+                className={`relative z-10 text-[10px] font-black tracking-[0.3em] uppercase ${
+                  isScanning ? "text-white" : "text-fuchsia-400"
+                }`}
+              >
+                {isScanning ? "SCANNING..." : "SYNC_NEURAL_DATA"}
+              </span>
+              {isScanning && <div className="absolute inset-0 bg-fuchsia-500/20 animate-pulse" />}
+            </button>
+          </div>
+
+          <div className="mt-6 text-[9px] opacity-80 uppercase tracking-[0.4em] text-fuchsia-400 font-black">
+            DATA_LINK_SYNCHRONIZED_BY_PRODUCER_AI
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/Artist/SoundCloudEmbed.tsx
+++ b/src/app/components/Artist/SoundCloudEmbed.tsx
@@ -1,0 +1,51 @@
+"use client";
+import React from "react";
+
+interface SoundCloudEmbedProps {
+  profileUrl: string;
+  title?: string;
+  height?: number;
+  visual?: boolean;
+  color?: string;
+}
+
+const SoundCloudEmbed: React.FC<SoundCloudEmbedProps> = ({
+  profileUrl,
+  title = "SoundCloud player",
+  height = 450,
+  visual = false,
+  color = "ff5500",
+}) => {
+  const params = new URLSearchParams({
+    url: profileUrl,
+    color: `#${color}`,
+    auto_play: "false",
+    hide_related: "false",
+    show_comments: "true",
+    show_user: "true",
+    show_reposts: "false",
+    show_teaser: "true",
+    visual: visual ? "true" : "false",
+  });
+
+  const src = `https://w.soundcloud.com/player/?${params.toString()}`;
+
+  return (
+    <div
+      className="w-full rounded-lg overflow-hidden bg-black"
+      style={{ height }}
+    >
+      <iframe
+        src={src}
+        title={title}
+        loading="lazy"
+        allow="autoplay"
+        scrolling="no"
+        frameBorder="no"
+        className="w-full h-full border-0"
+      />
+    </div>
+  );
+};
+
+export default SoundCloudEmbed;

--- a/src/app/components/Artist/Visualizer.tsx
+++ b/src/app/components/Artist/Visualizer.tsx
@@ -1,0 +1,123 @@
+"use client";
+import React, { useEffect, useRef } from "react";
+import * as THREE from "three";
+
+export default function Visualizer() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x000000);
+    scene.fog = new THREE.FogExp2(0x000000, 0.05);
+
+    const camera = new THREE.PerspectiveCamera(
+      75,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      1000,
+    );
+    camera.position.set(10, 5, 10);
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
+
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.2);
+    scene.add(ambientLight);
+
+    const pointLight = new THREE.PointLight(0x00ffff, 2, 50);
+    pointLight.position.set(5, 5, 5);
+    scene.add(pointLight);
+
+    const magentaLight = new THREE.PointLight(0xff00ff, 2, 50);
+    magentaLight.position.set(-5, 5, 5);
+    scene.add(magentaLight);
+
+    const gridHelper = new THREE.GridHelper(40, 40, 0x00ffff, 0x222222);
+    scene.add(gridHelper);
+
+    const cubes: THREE.Mesh[] = [];
+    const geometry = new THREE.BoxGeometry(0.5, 0.5, 0.5);
+
+    for (let i = 0; i < 60; i++) {
+      const material = new THREE.MeshPhongMaterial({
+        color: Math.random() > 0.5 ? 0x00ffff : 0xff00ff,
+        emissive: Math.random() > 0.5 ? 0x00ffff : 0xff00ff,
+        emissiveIntensity: 0.8,
+        transparent: true,
+        opacity: 0.9,
+      });
+      const cube = new THREE.Mesh(geometry, material);
+      cube.position.set(
+        (Math.random() - 0.5) * 20,
+        Math.random() * 8,
+        (Math.random() - 0.5) * 20,
+      );
+      scene.add(cube);
+      cubes.push(cube);
+    }
+
+    let frame = 0;
+    let frameId = 0;
+    const animate = () => {
+      frame += 0.01;
+      frameId = requestAnimationFrame(animate);
+
+      camera.position.x = Math.cos(frame * 0.2) * 15;
+      camera.position.z = Math.sin(frame * 0.2) * 15;
+      camera.lookAt(0, 0, 0);
+
+      cubes.forEach((cube, i) => {
+        cube.position.y += Math.sin(frame + i) * 0.02;
+        cube.rotation.x += 0.01;
+        cube.rotation.y += 0.01;
+
+        const scale = 1 + Math.sin(frame * 3 + i) * 0.6;
+        cube.scale.set(scale, scale, scale);
+      });
+
+      renderer.render(scene, camera);
+    };
+
+    animate();
+
+    const handleResize = () => {
+      if (!container) return;
+      camera.aspect = container.clientWidth / container.clientHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(container.clientWidth, container.clientHeight);
+    };
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener("resize", handleResize);
+      cubes.forEach((cube) => {
+        cube.geometry.dispose();
+        (cube.material as THREE.Material).dispose();
+      });
+      renderer.dispose();
+      if (container.contains(renderer.domElement)) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="w-full h-[350px] rounded-xl overflow-hidden border border-cyan-500/50 relative shadow-[0_0_40px_rgba(6,182,212,0.3)] bg-black"
+    >
+      <div className="absolute top-3 left-3 text-[10px] font-bold uppercase tracking-[0.3em] text-cyan-400 z-10 pointer-events-none drop-shadow-[0_0_5px_rgba(6,182,212,1)]">
+        RENDER_ENGINE_ACTIVE // SECTOR_3D
+      </div>
+      <div className="absolute bottom-3 right-3 text-[8px] font-bold uppercase tracking-widest text-fuchsia-500 z-10 pointer-events-none opacity-50">
+        AUTO_ORBIT_ENABLED
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/Utilities/EmailSection.tsx
+++ b/src/app/components/Utilities/EmailSection.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import GithubIcon from "../../../../public/images/icons/icons8-github-64.png";
 import LinkedinIcon from "../../../../public/images/icons/icons8-linkedin-64.png";
 import FacebookIcon from "../../../../public/images/icons/icons8-facebook-64.png" 
@@ -12,6 +12,11 @@ import Image from "next/image";
 
 const EmailSection = () => {
   const [emailSubmitted, setEmailSubmitted] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const handleSubmit = async (e: any) => {
     e.preventDefault();
@@ -84,7 +89,9 @@ const EmailSection = () => {
         </div>
       </div>
       <div>
-        {emailSubmitted ? (
+        {!mounted ? (
+          <div className="h-[400px]" aria-hidden="true" />
+        ) : emailSubmitted ? (
           <p className="text-green-500 text-sm mt-2">
             Email sent successfully!
           </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import AboutSection from "./components/AboutMe/AboutSection";
 import AchievementsSection from "./components/AboutMe/AchievementsSection";
 import ProjectsSection from "./components/Projects/ProjectsSection";
 import ListsPreview from "./components/Lists/ListsPreview";
+import ArtistSection from "./components/Artist/ArtistSection";
 import EmailSection from "./components/Utilities/EmailSection";
 import Footer from "./components/Footer";
 
@@ -15,6 +16,7 @@ export default function Home() {
         <HeroSection />
         <AchievementsSection />
         <AboutSection />
+        <ArtistSection />
         <ProjectsSection />
         <ListsPreview />
         <EmailSection />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -33,8 +33,10 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
-, "next.config.ts"  ],
+    ".next/types/**/*.ts",
+    "next.config.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": [
     "node_modules"
   ]


### PR DESCRIPTION
- New #artist anchor on home page combining the SoundCloud profile (visual dark mode, teal accent) with the Flow Music "Neural Link" player
- Flow Music adapted from Google's Flow space with 3 tracks and an OPEN_3D_SCAPE toggle that swaps in a Three.js visualizer; audio stays mounted across view switches so playback survives toggles
- Visualizer cleanup hardened: cancelAnimationFrame on unmount, geometry/material disposal, ref captured to avoid stale cleanup
- HeroSection: priority on hero image for LCP
- EmailSection: defer form to client mount, sidesteps Dashlane hydration mismatch from extension-injected attributes
- Dockerfile: chown .next to nextjs user so runtime image cache writes
- scripts/docker-local.sh: NO_CACHE=1 opt-in flag, LF line endings
- next.config.mjs: pin turbopack.root to project dir to silence the workspace-root inference warning from a parent bun.lock
- three + @types/three added; tsconfig/next-env.d.ts are Next 16 auto-edits