### PR TITLE
Add Supabase email client schema and Edge Functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,13 @@ Create `.env.local` (never commit):
 ```
 RESEND_API_KEY=your_key
 FROM_EMAIL=your_email@example.com
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key
 ```
+
+The `NEXT_PUBLIC_SUPABASE_*` vars power the `/mail` email client (Supabase
+Auth + database). When absent, the app still builds and `/mail` shows a
+"not configured" notice.
 
 ## Conventions
 

--- a/app/mail/layout.tsx
+++ b/app/mail/layout.tsx
@@ -1,0 +1,2 @@
+export { metadata } from '../../src/app/mail/layout';
+export { default } from '../../src/app/mail/layout';

--- a/app/mail/page.tsx
+++ b/app/mail/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../src/app/mail/page';

--- a/docs/email-client-setup.md
+++ b/docs/email-client-setup.md
@@ -1,0 +1,62 @@
+# Email Client Setup (`/mail`)
+
+Single-user email client at `/mail`: Supabase (`Personal-hub`,
+`twnhlikjjetzwjipddwq`) for auth/database/realtime, Resend for transport,
+`corey@cohurst.co` as the address.
+
+## Already provisioned
+
+- Database migrations applied (messages table + RLS, realtime publication,
+  attachments bucket) — sources in `supabase/migrations/`.
+- Edge Functions deployed: `receive-email` (JWT verification off, guarded by
+  Svix webhook signature) and `send-email` (JWT verification on) — sources in
+  `supabase/functions/`.
+- Resend domain `cohurst.co` created (sending + receiving, us-east-1).
+- Resend webhook for `email.received` →
+  `https://twnhlikjjetzwjipddwq.supabase.co/functions/v1/receive-email`.
+
+## DNS records (Route 53, hosted zone cohurst.co)
+
+| Type | Name                        | Value                                       | Priority |
+| ---- | --------------------------- | ------------------------------------------- | -------- |
+| TXT  | `resend._domainkey`         | `p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC8cx4DrjGYDJV+exDa+ZAr1P0rST8zDJeW2IbMjIq+SFnur7w0EGlqAMfMre/KM5FErTYwhkezZKRF+gXF1HR+w7xVR6YfQXAUERh/1jze83MElT6H0zthPdlkij67sJM+N5Pi+WilPt4hqLgnVb9UUAUWFTtgEMguU4uBNqweUwIDAQAB` | — |
+| MX   | `send`                      | `feedback-smtp.us-east-1.amazonses.com`     | 10       |
+| TXT  | `send`                      | `v=spf1 include:amazonses.com ~all`         | —        |
+| MX   | *(root, i.e. `cohurst.co`)* | `inbound-smtp.us-east-1.amazonaws.com`      | 0        |
+
+The root MX record routes ALL mail addressed to `@cohurst.co` into Resend
+receiving. Do not add it if another mail service (e.g. Google Workspace)
+already receives mail for this domain.
+
+After the records propagate, trigger verification from the Resend dashboard
+(Domains → cohurst.co → Verify).
+
+## Secrets to set (Supabase Dashboard → Edge Functions → Secrets)
+
+| Name                    | Value                                                  |
+| ----------------------- | ------------------------------------------------------ |
+| `RESEND_API_KEY`        | Create in Resend dashboard (sending access is enough)  |
+| `FROM_EMAIL`            | `corey@cohurst.co`                                     |
+| `RESEND_WEBHOOK_SECRET` | The `whsec_...` signing secret shown once when the webhook was created |
+
+## Frontend env (`.env.local` + Amplify environment variables)
+
+```
+NEXT_PUBLIC_SUPABASE_URL=https://twnhlikjjetzwjipddwq.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key from Dashboard → Settings → API>
+```
+
+## Auth (one-time, Supabase Dashboard)
+
+1. Authentication → Users → Add user: your email + password, auto-confirm.
+2. Authentication → Sign In / Providers → disable "Allow new users to sign
+   up" (the RLS policies trust any authenticated user, so signups must stay
+   closed).
+
+## Notes
+
+- Free-tier projects pause after ~1 week idle; restore from the dashboard if
+  `/mail` stops connecting.
+- Verify end-to-end: send yourself mail from `/mail` (outbound), and email
+  `corey@cohurst.co` from any account (inbound should appear in the inbox in
+  realtime).

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.18",
+    "@supabase/supabase-js": "^2.112.2",
     "@types/three": "^0.184.0",
     "autoprefixer": "10.4.15",
     "eslint": "8.47.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@heroicons/react':
     specifier: ^2.0.18
     version: 2.2.0(react@18.3.1)
+  '@supabase/supabase-js':
+    specifier: ^2.112.2
+    version: 2.112.2
   '@types/three':
     specifier: ^0.184.0
     version: 0.184.0
@@ -1026,6 +1029,63 @@ packages:
   /@sinclair/typebox@0.27.10:
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
     dev: true
+
+  /@supabase/auth-js@2.112.2:
+    resolution: {integrity: sha512-l1InCp4j98d09LZ6+RgubgF4eVPGBGXcLEhFusLg1qUCHJ2IEkYu5FohKK+eaFmIOwEk0kqG/j/lycw5e15mcQ==}
+    engines: {node: '>=22.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@supabase/functions-js@2.112.2:
+    resolution: {integrity: sha512-oMuSWN0ERmrG9S6kOM0bwhHmESGVl3kMtkZl2dNCU/r89hMiziX4GfD1omNo9QcBDele4N0GwSZ7hdbpuiA35A==}
+    engines: {node: '>=22.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@supabase/phoenix@0.4.5:
+    resolution: {integrity: sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==}
+    dev: false
+
+  /@supabase/postgrest-js@2.112.2:
+    resolution: {integrity: sha512-ewhhtRny/HFRGhUTTg/PsqIatsl8OhW8Eha/Tz4S+SRAXBnuhKei9ZpsQTgL/3XcH9UEwuPQyQgQ9itq7nRQeg==}
+    engines: {node: '>=22.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@supabase/realtime-js@2.112.2:
+    resolution: {integrity: sha512-cd9/CEUJ6Go13FxtfiuC5rYELJtuQzVzTXlGG+XjSppjDS+anq+xo++WQe7ZRUNTuHOCeyKRwmx9Hw/OQJ04ig==}
+    engines: {node: '>=22.0.0'}
+    dependencies:
+      '@supabase/phoenix': 0.4.5
+      tslib: 2.8.1
+    dev: false
+
+  /@supabase/storage-js@2.112.2:
+    resolution: {integrity: sha512-6jyBq/J1iXOHNpbjCZS7gFcDk49iM1MCJUVkDl71gLd/+XnLDzpUBs8icGebtwiHpl4kVszxIRDYAosbF4Rsig==}
+    engines: {node: '>=22.0.0'}
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+    dev: false
+
+  /@supabase/supabase-js@2.112.2:
+    resolution: {integrity: sha512-UyI1epU9B4X51HvNpkmlwTdF20fEcz2vyvrcDKVzFN4jZN41f5iQRqsiIQjAY5OVJD6ljqA/1g9JQeOTvFHpkA==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+    dependencies:
+      '@supabase/auth-js': 2.112.2
+      '@supabase/functions-js': 2.112.2
+      '@supabase/postgrest-js': 2.112.2
+      '@supabase/realtime-js': 2.112.2
+      '@supabase/storage-js': 2.112.2
+    dev: false
 
   /@swc/helpers@0.5.15:
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -2817,6 +2877,11 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
     dev: true
+
+  /iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
+    dev: false
 
   /ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}

--- a/src/app/components/Mail/AuthProvider.tsx
+++ b/src/app/components/Mail/AuthProvider.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import type { Session, SupabaseClient, User } from "@supabase/supabase-js";
+import getSupabaseClient from "@/lib/supabase";
+
+interface AuthContextValue {
+  supabase: SupabaseClient | null;
+  session: Session | null;
+  user: User | null;
+  loading: boolean;
+  signOut: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  supabase: null,
+  session: null,
+  user: null,
+  loading: true,
+  signOut: async () => {},
+});
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+export default function AuthProvider({ children }: { children: ReactNode }) {
+  const [supabase] = useState(() => getSupabaseClient());
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!supabase) {
+      setLoading(false);
+      return;
+    }
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session);
+      setLoading(false);
+    });
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, newSession) => {
+      setSession(newSession);
+      setLoading(false);
+    });
+    return () => subscription.unsubscribe();
+  }, [supabase]);
+
+  const signOut = async () => {
+    await supabase?.auth.signOut();
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        supabase,
+        session,
+        user: session?.user ?? null,
+        loading,
+        signOut,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/app/components/Mail/ComposeModal.tsx
+++ b/src/app/components/Mail/ComposeModal.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import React, { FormEvent, useState } from "react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { useAuth } from "./AuthProvider";
+
+interface ComposeModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function ComposeModal({ open, onClose }: ComposeModalProps) {
+  const { supabase } = useAuth();
+  const [to, setTo] = useState("");
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const handleSend = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!supabase) return;
+    setSending(true);
+    setError(null);
+
+    // The Edge Function sends via Resend and records the outbound row; the
+    // Sent folder picks it up through the Realtime subscription.
+    const { data, error: invokeError } = await supabase.functions.invoke(
+      "send-email",
+      { body: { to, subject, text: body } },
+    );
+
+    if (invokeError) {
+      setError(invokeError.message || "Failed to send email.");
+      setSending(false);
+      return;
+    }
+    if (data?.stored === false) {
+      setError(
+        "The email was sent, but recording it in the database failed.",
+      );
+      setSending(false);
+      return;
+    }
+
+    setTo("");
+    setSubject("");
+    setBody("");
+    setSending(false);
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg bg-[#181818] border border-[#33353F] rounded-xl shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between px-5 py-3 border-b border-[#33353F]">
+          <h2 className="text-white font-semibold">New message</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-[#ADB7BE] hover:text-white"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </header>
+
+        <form onSubmit={handleSend} className="p-5 flex flex-col gap-3">
+          <input
+            type="email"
+            placeholder="To"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            required
+            className="bg-[#121212] border border-[#33353F] text-white text-sm rounded-lg p-2.5"
+          />
+          <input
+            type="text"
+            placeholder="Subject"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            required
+            className="bg-[#121212] border border-[#33353F] text-white text-sm rounded-lg p-2.5"
+          />
+          <textarea
+            placeholder="Write your message…"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            required
+            rows={8}
+            className="bg-[#121212] border border-[#33353F] text-white text-sm rounded-lg p-2.5 resize-y"
+          />
+          {error && <p className="text-sm text-red-400">{error}</p>}
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-sm text-[#ADB7BE] hover:text-white px-4 py-2"
+            >
+              Discard
+            </button>
+            <button
+              type="submit"
+              disabled={sending}
+              className="bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-5 py-2"
+            >
+              {sending ? "Sending…" : "Send"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/Mail/LoginForm.tsx
+++ b/src/app/components/Mail/LoginForm.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import React, { FormEvent, useState } from "react";
+import { useAuth } from "./AuthProvider";
+
+export default function LoginForm() {
+  const { supabase } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  if (!supabase) {
+    return (
+      <p className="text-center text-[#ADB7BE]">
+        Supabase is not configured. Set NEXT_PUBLIC_SUPABASE_URL and
+        NEXT_PUBLIC_SUPABASE_ANON_KEY.
+      </p>
+    );
+  }
+
+  const handlePasswordSignIn = async (event: FormEvent) => {
+    event.preventDefault();
+    setPending(true);
+    setError(null);
+    setNotice(null);
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (signInError) setError(signInError.message);
+    setPending(false);
+  };
+
+  const handleMagicLink = async () => {
+    if (!email) {
+      setError("Enter your email first, then request a magic link.");
+      return;
+    }
+    setPending(true);
+    setError(null);
+    setNotice(null);
+    const { error: otpError } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        // Single-user app: never create accounts from the login screen.
+        shouldCreateUser: false,
+        emailRedirectTo:
+          typeof window !== "undefined" ? window.location.href : undefined,
+      },
+    });
+    if (otpError) {
+      setError(otpError.message);
+    } else {
+      setNotice("Magic link sent — check your inbox.");
+    }
+    setPending(false);
+  };
+
+  return (
+    <form
+      onSubmit={handlePasswordSignIn}
+      className="w-full max-w-sm flex flex-col gap-4"
+    >
+      <h1 className="text-2xl font-bold text-white text-center">Sign in</h1>
+      <label className="flex flex-col gap-1 text-sm text-[#ADB7BE]">
+        Email
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+          className="bg-[#18191E] border border-[#33353F] text-white rounded-lg p-2.5"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-sm text-[#ADB7BE]">
+        Password
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoComplete="current-password"
+          className="bg-[#18191E] border border-[#33353F] text-white rounded-lg p-2.5"
+        />
+      </label>
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+      {notice && <p className="text-primary-400 text-sm">{notice}</p>}
+      <button
+        type="submit"
+        disabled={pending}
+        className="bg-primary-500 hover:bg-primary-600 disabled:opacity-50 text-white font-medium rounded-lg py-2.5"
+      >
+        {pending ? "Working..." : "Sign in with password"}
+      </button>
+      <button
+        type="button"
+        onClick={handleMagicLink}
+        disabled={pending}
+        className="border border-primary-500 text-primary-400 hover:bg-[#18191E] disabled:opacity-50 font-medium rounded-lg py-2.5"
+      >
+        Email me a magic link
+      </button>
+    </form>
+  );
+}

--- a/src/app/components/Mail/MessageList.tsx
+++ b/src/app/components/Mail/MessageList.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React from "react";
+import type { Message } from "./types";
+
+interface MessageListProps {
+  messages: Message[];
+  loading: boolean;
+  error: string | null;
+  selectedId: string | null;
+  onSelect: (message: Message) => void;
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  const now = new Date();
+  return date.toDateString() === now.toDateString()
+    ? date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+    : date.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+export default function MessageList({
+  messages,
+  loading,
+  error,
+  selectedId,
+  onSelect,
+}: MessageListProps) {
+  if (loading) {
+    return <p className="p-4 text-sm text-[#ADB7BE]">Loading…</p>;
+  }
+  if (error) {
+    return <p className="p-4 text-sm text-red-400">{error}</p>;
+  }
+  if (messages.length === 0) {
+    return <p className="p-4 text-sm text-[#ADB7BE]">No messages.</p>;
+  }
+
+  return (
+    <ul className="overflow-y-auto divide-y divide-[#33353F]">
+      {messages.map((message) => {
+        const unread =
+          message.direction === "inbound" && !message.read_status;
+        return (
+          <li key={message.id}>
+            <button
+              onClick={() => onSelect(message)}
+              className={`w-full text-left px-4 py-3 transition-colors ${
+                message.id === selectedId
+                  ? "bg-primary-500/10"
+                  : "hover:bg-[#181818]"
+              }`}
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <span
+                  className={`truncate text-sm ${
+                    unread ? "text-white font-semibold" : "text-[#ADB7BE]"
+                  }`}
+                >
+                  {message.direction === "inbound"
+                    ? message.from_email
+                    : message.to_email}
+                </span>
+                <span className="text-xs text-[#ADB7BE] shrink-0">
+                  {formatTimestamp(message.created_at)}
+                </span>
+              </div>
+              <p
+                className={`truncate text-sm mt-0.5 ${
+                  unread ? "text-white" : "text-[#ADB7BE]"
+                }`}
+              >
+                {message.subject || "(no subject)"}
+              </p>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/app/components/Mail/MessageView.tsx
+++ b/src/app/components/Mail/MessageView.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React from "react";
+import type { Message } from "./types";
+
+// HTML bodies render in a sandboxed iframe (no scripts, no same-origin
+// access) since email HTML is untrusted content.
+export default function MessageView({ message }: { message: Message | null }) {
+  if (!message) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-[#ADB7BE]">
+        Select a message to read it.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 flex flex-col min-w-0">
+      <header className="border-b border-[#33353F] px-6 py-4">
+        <h2 className="text-lg font-semibold text-white">
+          {message.subject || "(no subject)"}
+        </h2>
+        <p className="text-sm text-[#ADB7BE] mt-1">
+          {message.direction === "inbound" ? "From" : "To"}:{" "}
+          {message.direction === "inbound"
+            ? message.from_email
+            : message.to_email}
+          <span className="mx-2">·</span>
+          {new Date(message.created_at).toLocaleString()}
+        </p>
+      </header>
+      <div className="flex-1 p-6 min-h-0">
+        {message.html_body ? (
+          <iframe
+            sandbox=""
+            srcDoc={message.html_body}
+            title={message.subject || "Email content"}
+            className="w-full h-full bg-white rounded-lg"
+          />
+        ) : (
+          <pre className="whitespace-pre-wrap font-sans text-sm text-[#E5E7EB]">
+            {message.text_body || "(empty message)"}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/Mail/ProtectedRoute.tsx
+++ b/src/app/components/Mail/ProtectedRoute.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React, { ReactNode } from "react";
+import { useAuth } from "./AuthProvider";
+import LoginForm from "./LoginForm";
+
+// Gate: children render only for a signed-in user; everyone else sees the
+// login screen. Wrap an entire layout in this to protect a whole app section.
+export default function ProtectedRoute({ children }: { children: ReactNode }) {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#121212]">
+        <p className="text-[#ADB7BE]">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#121212] px-4">
+        <LoginForm />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/components/Mail/Sidebar.tsx
+++ b/src/app/components/Mail/Sidebar.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import React from "react";
+import { InboxIcon, PaperAirplaneIcon } from "@heroicons/react/24/outline";
+import type { Folder } from "./types";
+
+interface SidebarProps {
+  folder: Folder;
+  onFolderChange: (folder: Folder) => void;
+  onCompose: () => void;
+  unreadCount: number;
+  userEmail: string | null;
+  onSignOut: () => void;
+}
+
+export default function Sidebar({
+  folder,
+  onFolderChange,
+  onCompose,
+  unreadCount,
+  userEmail,
+  onSignOut,
+}: SidebarProps) {
+  const itemClass = (active: boolean) =>
+    `w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+      active
+        ? "bg-primary-500/10 text-primary-400"
+        : "text-[#ADB7BE] hover:bg-[#181818] hover:text-white"
+    }`;
+
+  return (
+    <aside className="w-56 shrink-0 border-r border-[#33353F] flex flex-col p-4 gap-2">
+      <button
+        onClick={onCompose}
+        className="bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-lg py-2.5 mb-4"
+      >
+        Compose
+      </button>
+
+      <button
+        onClick={() => onFolderChange("inbox")}
+        className={itemClass(folder === "inbox")}
+      >
+        <InboxIcon className="h-5 w-5" />
+        <span className="flex-1 text-left">Inbox</span>
+        {unreadCount > 0 && (
+          <span className="bg-primary-500 text-white text-xs rounded-full px-2 py-0.5">
+            {unreadCount}
+          </span>
+        )}
+      </button>
+
+      <button
+        onClick={() => onFolderChange("sent")}
+        className={itemClass(folder === "sent")}
+      >
+        <PaperAirplaneIcon className="h-5 w-5" />
+        <span className="flex-1 text-left">Sent</span>
+      </button>
+
+      <div className="mt-auto pt-4 border-t border-[#33353F] flex flex-col gap-2">
+        {userEmail && (
+          <p className="text-xs text-[#ADB7BE] truncate" title={userEmail}>
+            {userEmail}
+          </p>
+        )}
+        <button
+          onClick={onSignOut}
+          className="text-left text-sm text-[#ADB7BE] hover:text-white"
+        >
+          Sign out
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/components/Mail/types.ts
+++ b/src/app/components/Mail/types.ts
@@ -1,0 +1,14 @@
+export interface Message {
+  id: string;
+  created_at: string;
+  direction: "inbound" | "outbound";
+  from_email: string;
+  to_email: string;
+  subject: string | null;
+  text_body: string | null;
+  html_body: string | null;
+  read_status: boolean;
+  thread_id: string | null;
+}
+
+export type Folder = "inbox" | "sent";

--- a/src/app/components/Mail/useMessages.ts
+++ b/src/app/components/Mail/useMessages.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "./AuthProvider";
+import type { Message } from "./types";
+
+// Fetches messages for one direction (newest first) and keeps the list live
+// via a Realtime subscription: rows inserted by the receive-email/send-email
+// Edge Functions appear instantly, and updates (e.g. read status) sync in.
+export default function useMessages(direction: "inbound" | "outbound") {
+  const { supabase } = useAuth();
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+
+    supabase
+      .from("messages")
+      .select("*")
+      .eq("direction", direction)
+      .order("created_at", { ascending: false })
+      .then(({ data, error: queryError }) => {
+        if (cancelled) return;
+        if (queryError) {
+          setError(queryError.message);
+        } else {
+          setError(null);
+          setMessages((data as Message[]) ?? []);
+        }
+        setLoading(false);
+      });
+
+    const channel = supabase
+      .channel(`messages-${direction}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "messages",
+          filter: `direction=eq.${direction}`,
+        },
+        (payload) => {
+          const row = payload.new as Message;
+          setMessages((prev) =>
+            prev.some((m) => m.id === row.id) ? prev : [row, ...prev],
+          );
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "messages",
+          filter: `direction=eq.${direction}`,
+        },
+        (payload) => {
+          const row = payload.new as Message;
+          setMessages((prev) =>
+            prev.map((m) => (m.id === row.id ? row : m)),
+          );
+        },
+      )
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      supabase.removeChannel(channel);
+    };
+  }, [supabase, direction]);
+
+  // Optimistic local update plus DB write, so read state is correct even if
+  // Realtime is unavailable.
+  const markAsRead = useCallback(
+    async (id: string) => {
+      setMessages((prev) =>
+        prev.map((m) => (m.id === id ? { ...m, read_status: true } : m)),
+      );
+      await supabase
+        ?.from("messages")
+        .update({ read_status: true })
+        .eq("id", id);
+    },
+    [supabase],
+  );
+
+  return { messages, loading, error, markAsRead };
+}

--- a/src/app/mail/layout.tsx
+++ b/src/app/mail/layout.tsx
@@ -1,0 +1,18 @@
+import React, { ReactNode } from "react";
+import AuthProvider from "@/app/components/Mail/AuthProvider";
+import ProtectedRoute from "@/app/components/Mail/ProtectedRoute";
+
+export const metadata = {
+  title: "Mail",
+  robots: { index: false, follow: false },
+};
+
+// Everything under /mail is the email client app; nothing inside renders
+// without a signed-in user.
+export default function MailLayout({ children }: { children: ReactNode }) {
+  return (
+    <AuthProvider>
+      <ProtectedRoute>{children}</ProtectedRoute>
+    </AuthProvider>
+  );
+}

--- a/src/app/mail/page.tsx
+++ b/src/app/mail/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@/app/components/Mail/AuthProvider";
+
+interface MessageRow {
+  id: string;
+  created_at: string;
+  direction: "inbound" | "outbound";
+  from_email: string;
+  to_email: string;
+  subject: string | null;
+  read_status: boolean;
+}
+
+export default function MailPage() {
+  const { supabase, user, signOut } = useAuth();
+  const [messages, setMessages] = useState<MessageRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadMessages = useCallback(async () => {
+    if (!supabase) return;
+    setLoading(true);
+    const { data, error: queryError } = await supabase
+      .from("messages")
+      .select(
+        "id, created_at, direction, from_email, to_email, subject, read_status",
+      )
+      .order("created_at", { ascending: false })
+      .limit(50);
+    if (queryError) {
+      setError(queryError.message);
+    } else {
+      setError(null);
+      setMessages((data as MessageRow[]) ?? []);
+    }
+    setLoading(false);
+  }, [supabase]);
+
+  useEffect(() => {
+    loadMessages();
+  }, [loadMessages]);
+
+  return (
+    <main className="min-h-screen bg-[#121212] text-white">
+      <div className="max-w-3xl mx-auto px-4 py-8">
+        <header className="flex items-center justify-between mb-8">
+          <h1 className="text-2xl font-bold">Inbox</h1>
+          <div className="flex items-center gap-4 text-sm text-[#ADB7BE]">
+            <span>{user?.email}</span>
+            <button
+              onClick={signOut}
+              className="border border-[#33353F] hover:border-primary-500 rounded-lg px-3 py-1.5"
+            >
+              Sign out
+            </button>
+          </div>
+        </header>
+
+        {error && <p className="text-red-400 mb-4">{error}</p>}
+        {loading && <p className="text-[#ADB7BE]">Loading messages…</p>}
+        {!loading && messages.length === 0 && !error && (
+          <p className="text-[#ADB7BE]">No messages yet.</p>
+        )}
+
+        <ul className="flex flex-col gap-2">
+          {messages.map((message) => (
+            <li
+              key={message.id}
+              className="bg-[#181818] border border-[#33353F] rounded-lg p-4"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span
+                  className={
+                    message.read_status || message.direction === "outbound"
+                      ? "text-[#ADB7BE]"
+                      : "text-white font-semibold"
+                  }
+                >
+                  {message.direction === "inbound"
+                    ? message.from_email
+                    : `To: ${message.to_email}`}
+                </span>
+                <span className="text-xs text-[#ADB7BE] shrink-0">
+                  {new Date(message.created_at).toLocaleString()}
+                </span>
+              </div>
+              <p className="mt-1 text-sm">
+                {message.subject || "(no subject)"}
+              </p>
+              <span
+                className={`inline-block mt-2 text-xs rounded px-1.5 py-0.5 ${
+                  message.direction === "inbound"
+                    ? "bg-primary-900 text-primary-300"
+                    : "bg-secondary-900 text-secondary-300"
+                }`}
+              >
+                {message.direction}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  );
+}

--- a/src/app/mail/page.tsx
+++ b/src/app/mail/page.tsx
@@ -1,107 +1,69 @@
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useAuth } from "@/app/components/Mail/AuthProvider";
-
-interface MessageRow {
-  id: string;
-  created_at: string;
-  direction: "inbound" | "outbound";
-  from_email: string;
-  to_email: string;
-  subject: string | null;
-  read_status: boolean;
-}
+import useMessages from "@/app/components/Mail/useMessages";
+import Sidebar from "@/app/components/Mail/Sidebar";
+import MessageList from "@/app/components/Mail/MessageList";
+import MessageView from "@/app/components/Mail/MessageView";
+import ComposeModal from "@/app/components/Mail/ComposeModal";
+import type { Folder, Message } from "@/app/components/Mail/types";
 
 export default function MailPage() {
-  const { supabase, user, signOut } = useAuth();
-  const [messages, setMessages] = useState<MessageRow[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const { user, signOut } = useAuth();
+  const inbox = useMessages("inbound");
+  const sent = useMessages("outbound");
 
-  const loadMessages = useCallback(async () => {
-    if (!supabase) return;
-    setLoading(true);
-    const { data, error: queryError } = await supabase
-      .from("messages")
-      .select(
-        "id, created_at, direction, from_email, to_email, subject, read_status",
-      )
-      .order("created_at", { ascending: false })
-      .limit(50);
-    if (queryError) {
-      setError(queryError.message);
-    } else {
-      setError(null);
-      setMessages((data as MessageRow[]) ?? []);
+  const [folder, setFolder] = useState<Folder>("inbox");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [composeOpen, setComposeOpen] = useState(false);
+
+  const active = folder === "inbox" ? inbox : sent;
+  const selected = useMemo(
+    () => active.messages.find((m) => m.id === selectedId) ?? null,
+    [active.messages, selectedId],
+  );
+  const unreadCount = inbox.messages.filter((m) => !m.read_status).length;
+
+  const handleFolderChange = (next: Folder) => {
+    setFolder(next);
+    setSelectedId(null);
+  };
+
+  const handleSelect = (message: Message) => {
+    setSelectedId(message.id);
+    if (message.direction === "inbound" && !message.read_status) {
+      inbox.markAsRead(message.id);
     }
-    setLoading(false);
-  }, [supabase]);
-
-  useEffect(() => {
-    loadMessages();
-  }, [loadMessages]);
+  };
 
   return (
-    <main className="min-h-screen bg-[#121212] text-white">
-      <div className="max-w-3xl mx-auto px-4 py-8">
-        <header className="flex items-center justify-between mb-8">
-          <h1 className="text-2xl font-bold">Inbox</h1>
-          <div className="flex items-center gap-4 text-sm text-[#ADB7BE]">
-            <span>{user?.email}</span>
-            <button
-              onClick={signOut}
-              className="border border-[#33353F] hover:border-primary-500 rounded-lg px-3 py-1.5"
-            >
-              Sign out
-            </button>
-          </div>
-        </header>
+    <main className="h-screen flex bg-[#121212] text-white">
+      <Sidebar
+        folder={folder}
+        onFolderChange={handleFolderChange}
+        onCompose={() => setComposeOpen(true)}
+        unreadCount={unreadCount}
+        userEmail={user?.email ?? null}
+        onSignOut={signOut}
+      />
 
-        {error && <p className="text-red-400 mb-4">{error}</p>}
-        {loading && <p className="text-[#ADB7BE]">Loading messages…</p>}
-        {!loading && messages.length === 0 && !error && (
-          <p className="text-[#ADB7BE]">No messages yet.</p>
-        )}
+      <section className="w-80 shrink-0 border-r border-[#33353F] flex flex-col">
+        <h1 className="px-4 py-4 text-lg font-semibold border-b border-[#33353F]">
+          {folder === "inbox" ? "Inbox" : "Sent"}
+        </h1>
+        <MessageList
+          messages={active.messages}
+          loading={active.loading}
+          error={active.error}
+          selectedId={selectedId}
+          onSelect={handleSelect}
+        />
+      </section>
 
-        <ul className="flex flex-col gap-2">
-          {messages.map((message) => (
-            <li
-              key={message.id}
-              className="bg-[#181818] border border-[#33353F] rounded-lg p-4"
-            >
-              <div className="flex items-center justify-between gap-2">
-                <span
-                  className={
-                    message.read_status || message.direction === "outbound"
-                      ? "text-[#ADB7BE]"
-                      : "text-white font-semibold"
-                  }
-                >
-                  {message.direction === "inbound"
-                    ? message.from_email
-                    : `To: ${message.to_email}`}
-                </span>
-                <span className="text-xs text-[#ADB7BE] shrink-0">
-                  {new Date(message.created_at).toLocaleString()}
-                </span>
-              </div>
-              <p className="mt-1 text-sm">
-                {message.subject || "(no subject)"}
-              </p>
-              <span
-                className={`inline-block mt-2 text-xs rounded px-1.5 py-0.5 ${
-                  message.direction === "inbound"
-                    ? "bg-primary-900 text-primary-300"
-                    : "bg-secondary-900 text-secondary-300"
-                }`}
-              >
-                {message.direction}
-              </span>
-            </li>
-          ))}
-        </ul>
-      </div>
+      <MessageView message={selected} />
+
+      <ComposeModal open={composeOpen} onClose={() => setComposeOpen(false)} />
     </main>
   );
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,16 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let client: SupabaseClient | null = null;
+
+// Returns null when the NEXT_PUBLIC_SUPABASE_* env vars are absent (e.g. CI
+// builds) so pages can render a "not configured" notice instead of crashing
+// during prerender.
+export default function getSupabaseClient(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+  if (!client) {
+    client = createClient(url, anonKey);
+  }
+  return client;
+}

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,6 @@
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};

--- a/supabase/functions/receive-email/index.ts
+++ b/supabase/functions/receive-email/index.ts
@@ -1,0 +1,127 @@
+// receive-email: webhook endpoint for inbound email from the provider
+// (Resend inbound webhooks, or any provider posting a compatible JSON body).
+//
+// Deploy with JWT verification OFF so the provider can reach it:
+//   supabase functions deploy receive-email --no-verify-jwt
+//
+// Secrets (supabase secrets set ...):
+//   RESEND_WEBHOOK_SECRET - signing secret from the Resend webhook config
+//                           (starts with "whsec_"). Requests that fail
+//                           signature verification are rejected, which is the
+//                           only thing keeping strangers from writing into
+//                           the inbox since RLS is bypassed here.
+//
+// SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are injected automatically.
+
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+const encoder = new TextEncoder();
+
+// Resend signs webhooks with Svix: HMAC-SHA256 over "{id}.{timestamp}.{body}"
+// keyed with the base64-decoded secret, compared against the space-separated
+// "v1,<base64sig>" entries in the svix-signature header.
+async function verifySignature(req: Request, rawBody: string): Promise<boolean> {
+  const secret = Deno.env.get("RESEND_WEBHOOK_SECRET");
+  if (!secret) return false;
+
+  const id = req.headers.get("svix-id");
+  const timestamp = req.headers.get("svix-timestamp");
+  const signatureHeader = req.headers.get("svix-signature");
+  if (!id || !timestamp || !signatureHeader) return false;
+
+  // Reject replayed or badly skewed requests (5 minute tolerance).
+  const ts = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(ts) || Math.abs(Date.now() / 1000 - ts) > 300) {
+    return false;
+  }
+
+  const secretBytes = Uint8Array.from(
+    atob(secret.replace(/^whsec_/, "")),
+    (c) => c.charCodeAt(0),
+  );
+  const key = await crypto.subtle.importKey(
+    "raw",
+    secretBytes,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const digest = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(`${id}.${timestamp}.${rawBody}`),
+  );
+  const expected = btoa(String.fromCharCode(...new Uint8Array(digest)));
+
+  return signatureHeader
+    .split(" ")
+    .some((part) => part.split(",")[1] === expected);
+}
+
+// Accepts either an address string ("Name <a@b.com>" or "a@b.com") or an
+// object like { email: "a@b.com" }, or an array of either.
+function extractEmail(value: unknown): string | null {
+  if (Array.isArray(value)) return extractEmail(value[0]);
+  if (value && typeof value === "object" && "email" in value) {
+    return extractEmail((value as { email: unknown }).email);
+  }
+  if (typeof value !== "string") return null;
+  const match = value.match(/<([^>]+)>/);
+  return (match ? match[1] : value).trim() || null;
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  const rawBody = await req.text();
+
+  if (!(await verifySignature(req, rawBody))) {
+    return new Response("Invalid signature", { status: 401 });
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return new Response("Invalid JSON", { status: 400 });
+  }
+
+  // Resend wraps the email in { type: "email.received", data: {...} };
+  // fall back to the top level for providers that post the email directly.
+  const data = (payload.data ?? payload) as Record<string, unknown>;
+
+  const fromEmail = extractEmail(data.from);
+  const toEmail = extractEmail(data.to);
+  if (!fromEmail || !toEmail) {
+    return new Response("Missing sender or recipient", { status: 400 });
+  }
+
+  // Service-role client: webhooks carry no user session, so RLS is bypassed.
+  const admin = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+
+  const { data: row, error } = await admin
+    .from("messages")
+    .insert({
+      direction: "inbound",
+      from_email: fromEmail,
+      to_email: toEmail,
+      subject: (data.subject as string) ?? null,
+      text_body: (data.text as string) ?? (data.text_body as string) ?? null,
+      html_body: (data.html as string) ?? (data.html_body as string) ?? null,
+      read_status: false,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    console.error("Failed to store inbound email:", error);
+    return new Response("Failed to store message", { status: 500 });
+  }
+
+  return Response.json({ id: row.id }, { status: 201 });
+});

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -1,0 +1,130 @@
+// send-email: authenticated endpoint the frontend calls to send an email
+// via Resend, then record it in the messages table as 'outbound'.
+//
+// Deploy with the default JWT verification ON (no extra flags needed) —
+// requests must carry a valid Supabase Auth session token.
+//
+// Secrets (supabase secrets set ...):
+//   RESEND_API_KEY - Resend API key
+//   FROM_EMAIL     - verified sender address, e.g. me@yourdomain.com
+//
+// SUPABASE_URL, SUPABASE_ANON_KEY and SUPABASE_SERVICE_ROLE_KEY are injected
+// automatically.
+//
+// Request body: { to: string, subject: string, text?: string, html?: string,
+//                 thread_id?: string (uuid) }
+
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { corsHeaders } from "../_shared/cors.ts";
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return json({ error: "Method not allowed" }, 405);
+  }
+
+  // Confirm the caller is the signed-in user. The platform already verified
+  // the JWT signature; this resolves it to an actual user and rejects
+  // anon-key-only calls.
+  const authHeader = req.headers.get("Authorization") ?? "";
+  const userClient = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_ANON_KEY")!,
+    { global: { headers: { Authorization: authHeader } } },
+  );
+  const {
+    data: { user },
+  } = await userClient.auth.getUser();
+  if (!user) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+
+  let body: {
+    to?: string;
+    subject?: string;
+    text?: string;
+    html?: string;
+    thread_id?: string;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const { to, subject, text, html, thread_id } = body;
+  if (!to || !subject || (!text && !html)) {
+    return json(
+      { error: "Required: to, subject, and text and/or html" },
+      400,
+    );
+  }
+
+  const fromEmail = Deno.env.get("FROM_EMAIL");
+  const resendApiKey = Deno.env.get("RESEND_API_KEY");
+  if (!fromEmail || !resendApiKey) {
+    return json({ error: "Email transport is not configured" }, 500);
+  }
+
+  const resendResponse = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${resendApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: fromEmail,
+      to: [to],
+      subject,
+      text,
+      html,
+    }),
+  });
+
+  if (!resendResponse.ok) {
+    const detail = await resendResponse.text();
+    console.error("Resend API error:", resendResponse.status, detail);
+    return json({ error: "Failed to send email" }, 502);
+  }
+
+  const { id: resendId } = await resendResponse.json();
+
+  // Record the sent message. The service-role client keeps this working even
+  // if the RLS policies are later pinned to a specific user id.
+  const admin = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+  const { data: row, error } = await admin
+    .from("messages")
+    .insert({
+      direction: "outbound",
+      from_email: fromEmail,
+      to_email: to,
+      subject,
+      text_body: text ?? null,
+      html_body: html ?? null,
+      read_status: true,
+      thread_id: thread_id ?? null,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    // The email already went out; surface the bookkeeping failure so the
+    // frontend can warn rather than silently losing the sent record.
+    console.error("Email sent but failed to store record:", error);
+    return json({ sent: true, resend_id: resendId, stored: false }, 500);
+  }
+
+  return json({ sent: true, resend_id: resendId, id: row.id }, 201);
+});

--- a/supabase/migrations/20260810000000_email_client_schema.sql
+++ b/supabase/migrations/20260810000000_email_client_schema.sql
@@ -1,0 +1,100 @@
+-- Email client schema: messages table, RLS, and attachments storage bucket.
+-- Single-user app: access is restricted to the authenticated user. Keep
+-- signups disabled in Supabase Auth (Dashboard > Authentication > Providers)
+-- so "authenticated" means only the owner's account.
+
+-- ---------------------------------------------------------------------------
+-- 1. messages table
+-- ---------------------------------------------------------------------------
+
+create type public.message_direction as enum ('inbound', 'outbound');
+
+create table public.messages (
+  id          uuid primary key default gen_random_uuid(),
+  created_at  timestamptz not null default now(),
+  direction   public.message_direction not null,
+  from_email  text not null,
+  to_email    text not null,
+  subject     text,
+  text_body   text,
+  html_body   text,
+  read_status boolean not null default false,
+  thread_id   uuid
+);
+
+-- Common access paths: newest-first inbox listing and thread grouping.
+create index messages_created_at_idx on public.messages (created_at desc);
+create index messages_thread_id_idx on public.messages (thread_id);
+
+-- ---------------------------------------------------------------------------
+-- 2. Row Level Security on messages
+-- ---------------------------------------------------------------------------
+
+alter table public.messages enable row level security;
+
+-- Only a logged-in user may touch rows; anon gets nothing. Because this is a
+-- single-user project with signups disabled, "authenticated" is only you.
+-- If you ever enable signups, replace the auth.uid() checks below with
+--   auth.uid() = '<your-user-uuid>'
+-- (find it under Dashboard > Authentication > Users).
+
+create policy "Owner can read messages"
+  on public.messages
+  for select
+  to authenticated
+  using (auth.uid() is not null);
+
+create policy "Owner can insert messages"
+  on public.messages
+  for insert
+  to authenticated
+  with check (auth.uid() is not null);
+
+create policy "Owner can update messages"
+  on public.messages
+  for update
+  to authenticated
+  using (auth.uid() is not null)
+  with check (auth.uid() is not null);
+
+create policy "Owner can delete messages"
+  on public.messages
+  for delete
+  to authenticated
+  using (auth.uid() is not null);
+
+-- ---------------------------------------------------------------------------
+-- 3. attachments storage bucket + policies
+-- ---------------------------------------------------------------------------
+
+insert into storage.buckets (id, name, public)
+values ('attachments', 'attachments', false)
+on conflict (id) do nothing;
+
+-- Storage RLS lives on storage.objects (RLS is already enabled on it by
+-- Supabase); scope every policy to this bucket.
+
+create policy "Owner can read attachments"
+  on storage.objects
+  for select
+  to authenticated
+  using (bucket_id = 'attachments');
+
+create policy "Owner can upload attachments"
+  on storage.objects
+  for insert
+  to authenticated
+  with check (bucket_id = 'attachments');
+
+create policy "Owner can update attachments"
+  on storage.objects
+  for update
+  to authenticated
+  using (bucket_id = 'attachments')
+  with check (bucket_id = 'attachments');
+
+create policy "Owner can delete attachments"
+  on storage.objects
+  for delete
+  to authenticated
+  using (bucket_id = 'attachments');

--- a/supabase/migrations/20260810010000_enable_realtime_messages.sql
+++ b/supabase/migrations/20260810010000_enable_realtime_messages.sql
@@ -1,0 +1,3 @@
+-- Broadcast messages table changes over Supabase Realtime (Postgres Changes).
+-- RLS still applies: only the authenticated owner receives events.
+alter publication supabase_realtime add table public.messages;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "supabase"
   ]
 }


### PR DESCRIPTION
## Summary

Supabase backend and frontend auth for the single-user email client: database schema, transport Edge Functions, and a protected `/mail` app.

### Migration (`supabase/migrations/20260810000000_email_client_schema.sql`)

- **`messages` table** — `id` (UUID, default `gen_random_uuid()`), `created_at` (timestamptz, default `now()`), `direction` (new `message_direction` enum: `inbound` / `outbound`), `from_email`, `to_email`, `subject`, `text_body`, `html_body`, `read_status` (boolean, default `false`), and `thread_id` (UUID). Includes indexes on `created_at desc` (inbox listing) and `thread_id` (thread grouping).
- **Row Level Security** — RLS enabled on `messages` with select/insert/update/delete policies granted only to the `authenticated` role. Since this is a single-user project, keep signups disabled in Supabase Auth so "authenticated" means only the owner; a comment in the migration explains how to pin policies to a specific user UUID if signups are ever enabled.
- **`attachments` storage bucket** — created as a private bucket, with `storage.objects` policies scoped to `bucket_id = 'attachments'` allowing read/upload/update/delete for authenticated users only.

### Edge Functions (`supabase/functions/`)

- **`receive-email`** — inbound webhook for the email provider. Verifies the Resend/Svix HMAC signature (`RESEND_WEBHOOK_SECRET`, with a 5-minute replay window), parses the payload (handles both Resend's `{ type, data }` envelope and flat payloads, and address strings/objects/arrays), and inserts the message as `inbound` using the service-role client since webhooks carry no user session. Deploy with `--no-verify-jwt`.
- **`send-email`** — authenticated endpoint for the frontend. Resolves the caller via `auth.getUser()` (401 otherwise), validates the body (`to`, `subject`, `text` and/or `html`, optional `thread_id`), sends through the Resend API, then records the message as `outbound` with `read_status = true`. Handles CORS preflight; if the send succeeds but the insert fails, it reports `stored: false` instead of silently losing the record.
- **`_shared/cors.ts`** — shared CORS headers.
- `supabase/` is excluded from the Next.js `tsconfig.json` since the Edge Functions use Deno-style `jsr:` imports the Node toolchain can't resolve.

### Frontend auth + protected `/mail` app

- **`src/lib/supabase.ts`** — browser client singleton for `@supabase/supabase-js` (new dependency). Returns `null` when `NEXT_PUBLIC_SUPABASE_*` env vars are absent so CI builds and unconfigured environments render a notice instead of crashing.
- **`src/app/components/Mail/AuthProvider.tsx`** — React context exposing `supabase`, `session`, `user`, `loading`, and `signOut`, kept in sync via `onAuthStateChange`.
- **`src/app/components/Mail/LoginForm.tsx`** — email/password sign-in plus a magic-link option (`signInWithOtp` with `shouldCreateUser: false`, so the login screen can never create accounts).
- **`src/app/components/Mail/ProtectedRoute.tsx`** — renders children only for a signed-in user; otherwise the login screen.
- **`src/app/mail/`** — the email client app, entirely wrapped in `AuthProvider` + `ProtectedRoute` via its layout (marked `noindex`). The initial page is a simple inbox reading from `messages`. Root-level `app/mail/` shims re-export these, matching the repo's existing `app/` → `src/app/` pattern. The public portfolio routes remain unauthenticated.

### Configuration

- Frontend env vars (`.env.local` / Amplify): `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` (documented in CLAUDE.md).
- Function secrets (`supabase secrets set ...`): `RESEND_API_KEY`, `FROM_EMAIL`, `RESEND_WEBHOOK_SECRET`.
- Apply the migration via `supabase db push` or the Dashboard SQL editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GamiiyDGuxMEKAWhd2ait